### PR TITLE
Add ls command for listing and attaching containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ docker exec -it <container-name> /bin/bash
 
 The container name will be displayed when `codesandbox` runs.
 
+## Listing Existing Containers
+
+List all sandbox containers created from the current directory and optionally attach to one:
+
+```bash
+codesandbox ls
+```
+
+You will be shown a numbered list of containers. Enter a number to attach or press Enter to cancel.
+
 ## Container Contents
 
 -   **Base**: Ubuntu 22.04

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "codesandbox")]
@@ -7,12 +7,25 @@ pub struct Cli {
     #[arg(
         long,
         help = "Resume the last created container",
-        conflicts_with = "cleanup"
+        conflicts_with_all = ["cleanup", "command"]
     )]
     pub continue_: bool,
 
-    #[arg(long, help = "Remove all containers created from this directory")]
+    #[arg(
+        long,
+        help = "Remove all containers created from this directory",
+        conflicts_with_all = ["continue_", "command"]
+    )]
     pub cleanup: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    #[command(about = "List containers for this directory and optionally attach to one")]
+    Ls,
 }
 
 impl Cli {

--- a/src/container.rs
+++ b/src/container.rs
@@ -81,6 +81,35 @@ pub fn cleanup_containers(current_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn list_containers(current_dir: &Path) -> Result<Vec<String>> {
+    let dir_name = current_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(sanitize)
+        .unwrap_or_else(|| "unknown".to_string());
+    let prefix = format!("csb-{dir_name}-");
+
+    let list_output = Command::new("docker")
+        .args(["ps", "-a", "--format", "{{.Names}}"])
+        .output()
+        .context("Failed to list Docker containers")?;
+
+    if !list_output.status.success() {
+        anyhow::bail!(
+            "Failed to list containers: {}",
+            String::from_utf8_lossy(&list_output.stderr)
+        );
+    }
+
+    let names = String::from_utf8_lossy(&list_output.stdout);
+    let containers = names
+        .lines()
+        .filter(|n| n.starts_with(&prefix))
+        .map(|s| s.to_string())
+        .collect();
+    Ok(containers)
+}
+
 pub fn check_docker_availability() -> Result<()> {
     let output = Command::new("docker").arg("--version").output().context(
         "Failed to check Docker availability. Make sure Docker is installed and running.",


### PR DESCRIPTION
## Summary
- add `codesandbox ls` subcommand to list containers for current directory with numbered options
- implement container listing helper and interactive selection
- document `codesandbox ls` usage in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a3048127e4832f8a0713b3f6b9ba39