### PR TITLE
feat: add optional read-only directory mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ This will:
 3. Copy your `.claude` config from `~/.claude` (if it exists)
 4. Install and start Claude Code in the container
 
+To mount an additional directory read-only inside the container, use:
+
+```
+codesandbox --add_dir /path/to/other/repo
+```
+
 ## Connecting to the Container
 
 After the container is created, you can connect to it using:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "codesandbox")]
@@ -17,6 +18,13 @@ pub struct Cli {
         conflicts_with = "continue_"
     )]
     pub cleanup: bool,
+
+    #[arg(
+        long = "add_dir",
+        value_name = "DIR",
+        help = "Additional directory to mount read-only inside the container"
+    )]
+    pub add_dir: Option<PathBuf>,
 
     #[command(subcommand)]
     pub command: Option<Commands>,

--- a/src/container.rs
+++ b/src/container.rs
@@ -146,7 +146,11 @@ pub fn container_exists(container_name: &str) -> Result<bool> {
     Ok(output.status.success())
 }
 
-pub async fn create_container(container_name: &str, current_dir: &Path) -> Result<()> {
+pub async fn create_container(
+    container_name: &str,
+    current_dir: &Path,
+    additional_dir: Option<&Path>,
+) -> Result<()> {
     let current_user = env::var("USER").unwrap_or_else(|_| "ubuntu".to_string());
     let dockerfile_content = create_dockerfile_content(&current_user);
 
@@ -185,6 +189,11 @@ pub async fn create_container(container_name: &str, current_dir: &Path) -> Resul
         "-v",
         &format!("{}:{}", current_dir.display(), current_dir.display()),
     ]);
+
+    if let Some(dir) = additional_dir {
+        docker_run.args(&["-v", &format!("{}:{}:ro", dir.display(), dir.display())]);
+        println!("Mounting additional directory read-only: {}", dir.display());
+    }
 
     if let Some(claude_config_dir) = get_claude_config_dir() {
         if claude_config_dir.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod state;
 
 use anyhow::{Context, Result};
 use std::env;
+use std::fs;
 use std::io::{self, Write};
 
 use cli::{Cli, Commands};
@@ -76,11 +77,19 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    let additional_dir = match &cli.add_dir {
+        Some(dir) => Some(
+            fs::canonicalize(dir)
+                .with_context(|| format!("Failed to canonicalize path {}", dir.display()))?,
+        ),
+        None => None,
+    };
+
     let container_name = generate_container_name(&current_dir);
 
     println!("Starting Claude Code Sandbox container: {container_name}");
 
-    create_container(&container_name, &current_dir).await?;
+    create_container(&container_name, &current_dir, additional_dir.as_deref()).await?;
     save_last_container(&container_name)?;
 
     println!("Container {container_name} started successfully!");

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -10,6 +10,7 @@ fn parse_continue_flag() {
     let cli = Cli::parse_from(["codesandbox", "--continue"]);
     assert!(cli.continue_);
     assert!(!cli.cleanup);
+    assert!(cli.add_dir.is_none());
 }
 
 #[test]
@@ -17,16 +18,27 @@ fn parse_cleanup_flag() {
     let cli = Cli::parse_from(["codesandbox", "--cleanup"]);
     assert!(cli.cleanup);
     assert!(!cli.continue_);
+    assert!(cli.add_dir.is_none());
 }
 
 #[test]
 fn parse_ls_subcommand() {
     let cli = Cli::parse_from(["codesandbox", "ls"]);
     assert!(matches!(cli.command, Some(Commands::Ls)));
+    assert!(cli.add_dir.is_none());
 }
 
 #[test]
 fn conflicting_flags_error() {
     let result = Cli::try_parse_from(["codesandbox", "--continue", "--cleanup"]);
     assert!(result.is_err());
+}
+
+#[test]
+fn parse_add_dir() {
+    let cli = Cli::parse_from(["codesandbox", "--add_dir", "/tmp/foo"]);
+    assert_eq!(
+        cli.add_dir.as_deref(),
+        Some(std::path::Path::new("/tmp/foo"))
+    );
 }


### PR DESCRIPTION
## Summary
- allow passing `--add_dir` to mount an extra directory read-only at the same path
- document new option and test CLI parsing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a31056e304832f96bc81aa0e35af77