### PR TITLE
feat: auto remove idle containers

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,84 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Debug)]
+pub struct Settings {
+    pub auto_remove_minutes: Option<u64>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            auto_remove_minutes: Some(60),
+        }
+    }
+}
+
+fn settings_file_path() -> PathBuf {
+    if let Ok(dir) = env::var("CODESANDBOX_CONFIG_HOME") {
+        return PathBuf::from(dir).join("settings.json");
+    }
+    let home = home::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    home.join(".config")
+        .join("codesandbox")
+        .join("settings.json")
+}
+
+pub fn load_settings() -> Result<Settings> {
+    let path = settings_file_path();
+    if let Ok(data) = fs::read_to_string(path) {
+        if let Ok(settings) = serde_json::from_str::<Settings>(&data) {
+            return Ok(settings);
+        }
+    }
+    Ok(Settings::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn default_when_missing() {
+        let tmp = tempdir().unwrap();
+        let original = env::var("CODESANDBOX_CONFIG_HOME").ok();
+        env::set_var("CODESANDBOX_CONFIG_HOME", tmp.path());
+
+        let settings = load_settings().unwrap();
+        assert_eq!(settings.auto_remove_minutes, Some(60));
+
+        if let Some(val) = original {
+            env::set_var("CODESANDBOX_CONFIG_HOME", val);
+        } else {
+            env::remove_var("CODESANDBOX_CONFIG_HOME");
+        }
+    }
+
+    #[test]
+    fn read_from_file() {
+        let tmp = tempdir().unwrap();
+        let config_dir = tmp.path();
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("settings.json"),
+            r#"{ "auto_remove_minutes": 30 }"#,
+        )
+        .unwrap();
+
+        let original = env::var("CODESANDBOX_CONFIG_HOME").ok();
+        env::set_var("CODESANDBOX_CONFIG_HOME", config_dir);
+
+        let settings = load_settings().unwrap();
+        assert_eq!(settings.auto_remove_minutes, Some(30));
+
+        if let Some(val) = original {
+            env::set_var("CODESANDBOX_CONFIG_HOME", val);
+        } else {
+            env::remove_var("CODESANDBOX_CONFIG_HOME");
+        }
+    }
+}

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -4,10 +4,9 @@ mod config;
 #[path = "../src/container.rs"]
 mod container;
 
-use container::generate_container_name;
+use container::{auto_remove_old_containers, generate_container_name};
+use std::{env, fs, process::Command};
 use tempfile::tempdir;
-use std::fs;
-use std::process::Command;
 
 #[test]
 fn test_generate_container_name_with_git_repo() {
@@ -59,4 +58,66 @@ fn test_generate_container_name_without_git_repo() {
     let ts = &name[prefix.len()..];
     assert_eq!(ts.len(), 10);
     assert!(ts.chars().all(|c| c.is_ascii_digit()));
+}
+
+#[test]
+fn test_auto_remove_old_containers() {
+    let tmp = tempdir().expect("temp dir");
+    let bin_dir = tmp.path();
+    let rm_log = bin_dir.join("rm.log");
+
+    let docker_path = bin_dir.join("docker");
+    let script = r#"#!/bin/bash
+set -e
+cmd="$1"
+shift
+case "$cmd" in
+  ps)
+    echo "csb-old"
+    echo "csb-recent"
+    ;;
+  inspect)
+    name="${!#}"
+    if [ "$name" = "csb-old" ]; then
+      echo "1970-01-01T00:00:00Z"
+    else
+      date -u +"%Y-%m-%dT%H:%M:%SZ"
+    fi
+    ;;
+  logs)
+    name="${!#}"
+    if [ "$name" = "csb-old" ]; then
+      :
+    else
+      echo "has logs"
+    fi
+    ;;
+  rm)
+    name="${!#}"
+    echo "$name" >> "__LOG__"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+"#
+    .replace("__LOG__", rm_log.to_str().unwrap());
+    fs::write(&docker_path, script).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&docker_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&docker_path, perms).unwrap();
+    }
+
+    let original_path = env::var("PATH").unwrap_or_default();
+    env::set_var("PATH", format!("{}:{}", bin_dir.display(), original_path));
+
+    auto_remove_old_containers(1).unwrap();
+
+    env::set_var("PATH", original_path);
+
+    let removed = fs::read_to_string(&rm_log).unwrap();
+    assert_eq!(removed.trim(), "csb-old");
 }


### PR DESCRIPTION
## Summary
- automatically purge unused Code Sandbox containers with no logs after a configurable time
- load configurable timeout from `~/.config/codesandbox/settings.json`
- read settings on startup and clean old containers accordingly
- add unit test validating automatic container cleanup

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a31453351c832f8350134f3e8e6371