### PR TITLE
Include agent in container name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,4 +78,4 @@ Containers are created with:
 
 ## Container Management
 
-The tool generates contextual container names using the format `csb-{dir}-{branch}-{yymmddhhmm}` and tracks the last container for resumption. State is persisted in `~/.config/codesandbox/last_container`.
+The tool generates contextual container names using the format `csb-{agent}-{dir}-{branch}-{yymmddhhmm}` and tracks the last container for resumption. State is persisted in `~/.config/codesandbox/last_container`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Rust CLI tool that creates isolated Ubuntu Docker containers with a developmen
 -   Mounts current directory to `/workspace` in the container
 -   Automatically copies your `.claude` configuration
 -   Starts the selected agent in the container
--   Generates contextual container names to avoid conflicts (`csb-{dir}-{branch}-{yymmddhhmm}`)
+-   Generates contextual container names to avoid conflicts (`csb-{agent}-{dir}-{branch}-{yymmddhhmm}`)
 -   Cleans up all containers for a directory with `codesandbox --cleanup`
 
 ## Prerequisites
@@ -43,7 +43,7 @@ codesandbox
 
 This will:
 
-1. Create a new Ubuntu container with a unique name (e.g., `csb-project-main-2401011230`)
+1. Create a new Ubuntu container with a unique name (e.g., `csb-claude-project-main-2401011230`)
 2. Mount the current directory to `/workspace` in the container
 3. Copy your `.claude` config from `~/.claude` (if it exists)
 4. Install and start the selected agent in the container

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
         None => None,
     };
 
-    let container_name = generate_container_name(&current_dir);
+    let container_name = generate_container_name(&current_dir, &cli.agent);
 
     println!(
         "Starting {} Code Sandbox container: {container_name}",

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -7,6 +7,7 @@ mod cli;
 #[path = "../src/container.rs"]
 mod container;
 
+use cli::Agent;
 use container::{auto_remove_old_containers, generate_container_name};
 use std::{env, fs, process::Command};
 use tempfile::tempdir;
@@ -41,8 +42,8 @@ fn test_generate_container_name_with_git_repo() {
         .status()
         .expect("git commit");
 
-    let name = generate_container_name(&repo_path);
-    let prefix = "csb-my-repo--feature-test-";
+    let name = generate_container_name(&repo_path, &Agent::Claude);
+    let prefix = "csb-claude-my-repo--feature-test-";
     assert!(name.starts_with(prefix));
     let ts = &name[prefix.len()..];
     assert_eq!(ts.len(), 10);
@@ -55,8 +56,8 @@ fn test_generate_container_name_without_git_repo() {
     let dir_path = tmp.path().join("Another Repo");
     fs::create_dir(&dir_path).expect("create dir");
 
-    let name = generate_container_name(&dir_path);
-    let prefix = "csb-another-repo-unknown-";
+    let name = generate_container_name(&dir_path, &Agent::Claude);
+    let prefix = "csb-claude-another-repo-unknown-";
     assert!(name.starts_with(prefix));
     let ts = &name[prefix.len()..];
     assert_eq!(ts.len(), 10);

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -7,6 +7,7 @@ mod cli;
 #[path = "../src/container.rs"]
 mod container;
 
+use cli::Agent;
 use std::fs;
 use tempfile::tempdir;
 
@@ -16,7 +17,7 @@ fn test_generate_container_name_sanitizes_directory() {
     let project_dir = tmp_dir.path().join("My Project");
     fs::create_dir(&project_dir).expect("create project dir");
 
-    let name = container::generate_container_name(&project_dir);
+    let name = container::generate_container_name(&project_dir, &Agent::Claude);
 
-    assert!(name.starts_with("csb-my-project-"));
+    assert!(name.starts_with("csb-claude-my-project-"));
 }


### PR DESCRIPTION
## Summary
- include selected agent in generated Docker container names
- update cleanup and list logic to accommodate agent-prefixed names
- document new naming convention and adjust tests

## Testing
- `cargo fmt --check` *(fails: diff from rustfmt for existing files)*
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a31cce4100832f8cd8339ec8c862c7