### PR TITLE
Add git worktree support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,13 @@ pub struct Cli {
     pub add_dir: Option<PathBuf>,
 
     #[arg(
+        long = "worktree",
+        value_name = "BRANCH",
+        help = "Create and use a git worktree for the specified branch"
+    )]
+    pub worktree: Option<String>,
+
+    #[arg(
         long,
         value_enum,
         default_value_t = Agent::Claude,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod container;
 mod settings;
 mod state;
+mod worktree;
 
 use anyhow::{Context, Result};
 use std::env;
@@ -16,11 +17,16 @@ use container::{
 };
 use settings::load_settings;
 use state::{clear_last_container, load_last_container, save_last_container};
+use worktree::create_worktree;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse_args();
-    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let mut current_dir = env::current_dir().context("Failed to get current directory")?;
+    if let Some(branch) = &cli.worktree {
+        current_dir = create_worktree(&current_dir, branch)
+            .with_context(|| format!("Failed to create worktree for branch {}", branch))?;
+    }
     let settings = load_settings().unwrap_or_default();
 
     check_docker_availability()?;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,0 +1,34 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn create_worktree(base_dir: &Path, branch: &str) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(base_dir)
+        .output()
+        .context("Failed to determine git repository root")?;
+    if !output.status.success() {
+        anyhow::bail!("Not a git repository");
+    }
+    let root = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+    let worktrees_dir = root.join(".csb-worktrees");
+    fs::create_dir_all(&worktrees_dir).context("Failed to create worktrees directory")?;
+    let worktree_path = worktrees_dir.join(branch);
+    let status = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "--force",
+            worktree_path.to_str().unwrap(),
+            branch,
+        ])
+        .current_dir(&root)
+        .status()
+        .context("Failed to add git worktree")?;
+    if !status.success() {
+        anyhow::bail!("git worktree add failed");
+    }
+    Ok(worktree_path)
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -54,3 +54,9 @@ fn parse_agent_option() {
     let cli = Cli::parse_from(["codesandbox", "--agent", "qwen"]);
     assert!(matches!(cli.agent, Agent::Qwen));
 }
+
+#[test]
+fn parse_worktree_option() {
+    let cli = Cli::parse_from(["codesandbox", "--worktree", "feature"]);
+    assert_eq!(cli.worktree.as_deref(), Some("feature"));
+}


### PR DESCRIPTION
## Summary
- add `--worktree` flag to generate and use a git worktree for a specified branch
- create `worktree` module to handle git worktree creation
- cover new flag with CLI test

## Testing
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68a327e676f4832fbc0867d379d41e38