### PR TITLE
Handle missing branches when creating worktrees

### DIFF
--- a/tests/worktree_test.rs
+++ b/tests/worktree_test.rs
@@ -1,0 +1,40 @@
+use std::{fs, process::Command};
+use tempfile::tempdir;
+
+#[path = "../src/worktree.rs"]
+mod worktree;
+
+use worktree::create_worktree;
+
+#[test]
+fn create_missing_branch() {
+    let tmp = tempdir().expect("temp dir");
+    let repo_path = tmp.path();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(repo_path)
+        .status()
+        .expect("git init");
+    fs::write(repo_path.join("file.txt"), "test").expect("write file");
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(repo_path)
+        .status()
+        .expect("git commit");
+
+    let worktree = create_worktree(repo_path, "feature").expect("create worktree");
+    assert!(worktree.exists());
+
+    let branch_status = Command::new("git")
+        .args(["rev-parse", "--verify", "feature"])
+        .current_dir(repo_path)
+        .status()
+        .expect("git rev-parse");
+    assert!(branch_status.success());
+}


### PR DESCRIPTION
## Summary
- create worktree branches automatically when missing
- test creating worktree on new branch

## Testing
- `cargo fmt --check -- src/worktree.rs tests/worktree_test.rs`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a32a6bd664832fa95b871474851564