### PR TITLE
Attach to existing worktree containers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,15 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    if cli.worktree.is_some() {
+        let containers = list_containers(&current_dir)?;
+        if let Some(latest) = containers.first() {
+            println!("Attaching to existing container for worktree: {}", latest);
+            resume_container(latest, &cli.agent).await?;
+            return Ok(());
+        }
+    }
+
     let additional_dir = match &cli.add_dir {
         Some(dir) => Some(
             fs::canonicalize(dir)

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -16,26 +16,28 @@ pub fn create_worktree(base_dir: &Path, branch: &str) -> Result<PathBuf> {
     let worktrees_dir = root.join(".codesandbox-worktrees");
     fs::create_dir_all(&worktrees_dir).context("Failed to create worktrees directory")?;
     let worktree_path = worktrees_dir.join(branch);
-    let branch_exists = Command::new("git")
-        .args(["rev-parse", "--verify", branch])
-        .current_dir(&root)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    let mut cmd = Command::new("git");
-    cmd.args(["worktree", "add", "--force"]);
-    if branch_exists {
-        cmd.arg(worktree_path.to_str().unwrap());
-        cmd.arg(branch);
-    } else {
-        cmd.args(["-b", branch, worktree_path.to_str().unwrap()]);
-    }
-    let status = cmd
-        .current_dir(&root)
-        .status()
-        .context("Failed to add git worktree")?;
-    if !status.success() {
-        anyhow::bail!("git worktree add failed");
+    if !worktree_path.exists() {
+        let branch_exists = Command::new("git")
+            .args(["rev-parse", "--verify", branch])
+            .current_dir(&root)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        let mut cmd = Command::new("git");
+        cmd.args(["worktree", "add", "--force"]);
+        if branch_exists {
+            cmd.arg(worktree_path.to_str().unwrap());
+            cmd.arg(branch);
+        } else {
+            cmd.args(["-b", branch, worktree_path.to_str().unwrap()]);
+        }
+        let status = cmd
+            .current_dir(&root)
+            .status()
+            .context("Failed to add git worktree")?;
+        if !status.success() {
+            anyhow::bail!("git worktree add failed");
+        }
     }
     Ok(worktree_path)
 }

--- a/tests/worktree_test.rs
+++ b/tests/worktree_test.rs
@@ -38,3 +38,31 @@ fn create_missing_branch() {
         .expect("git rev-parse");
     assert!(branch_status.success());
 }
+
+#[test]
+fn reuse_existing_worktree() {
+    let tmp = tempdir().expect("temp dir");
+    let repo_path = tmp.path();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(repo_path)
+        .status()
+        .expect("git init");
+    fs::write(repo_path.join("file.txt"), "test").expect("write file");
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(repo_path)
+        .status()
+        .expect("git commit");
+
+    let first = create_worktree(repo_path, "feature").expect("create worktree");
+    let second = create_worktree(repo_path, "feature").expect("reuse worktree");
+    assert!(first.exists());
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary
- Skip creating a git worktree if the target directory already exists
- When `--worktree` is specified, reuse the most recent container for that worktree instead of creating a new one
- Add tests for reusing existing worktrees

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a32f89e40c832f8ee6ab9cddc24839