### PR TITLE
Make permission skipping configurable per agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The codebase is structured into focused modules:
 ### Dependencies and External Tools
 
 -   **Docker**: Required for container operations - tool validates availability before proceeding
--   **Claude Code**: Automatically installed via npm in containers and launched with `--dangerously-skip-permissions` flag
+-   **Claude Code**: Automatically installed via npm in containers and can be launched with agent-specific permission-skipping flags (e.g., `--dangerously-skip-permissions`, `--yolo`) configured in `settings.json`
 -   **Development Tools**: Containers include Node.js v22, Go 1.24.5, Rust/Cargo, Python3, and build-essential
 
 ### Container Environment

--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ The tool automatically detects and mounts your Claude configuration from:
 -   `~/.claude` (standard location)
 -   `$XDG_CONFIG_HOME/claude` (XDG standard)
 
+Additional behavior can be configured via `settings.json` located at
+`~/.config/codesandbox/settings.json`. Example:
+
+```json
+{
+  "auto_remove_minutes": 30,
+  "skip_permission_flags": {
+    "claude": "--dangerously-skip-permissions",
+    "gemini": "--yolo",
+    "qwen": "--yolo"
+  }
+}
+```
+
+The `skip_permission_flags` map assigns a permission-skipping flag to each
+agent. When launching an agent, the corresponding flag is appended to the
+command.
+
 ## Cleanup
 
 To remove all containers created from the current directory:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -7,12 +8,15 @@ use std::path::PathBuf;
 #[derive(Deserialize, Debug)]
 pub struct Settings {
     pub auto_remove_minutes: Option<u64>,
+    #[serde(default)]
+    pub skip_permission_flags: HashMap<String, String>,
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Self {
             auto_remove_minutes: Some(60),
+            skip_permission_flags: HashMap::new(),
         }
     }
 }
@@ -50,6 +54,7 @@ mod tests {
 
         let settings = load_settings().unwrap();
         assert_eq!(settings.auto_remove_minutes, Some(60));
+        assert!(settings.skip_permission_flags.is_empty());
 
         if let Some(val) = original {
             env::set_var("CODESANDBOX_CONFIG_HOME", val);
@@ -65,7 +70,7 @@ mod tests {
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("settings.json"),
-            r#"{ "auto_remove_minutes": 30 }"#,
+            r#"{ "auto_remove_minutes": 30, "skip_permission_flags": { "claude": "--dangerously-skip-permissions" } }"#,
         )
         .unwrap();
 
@@ -74,6 +79,13 @@ mod tests {
 
         let settings = load_settings().unwrap();
         assert_eq!(settings.auto_remove_minutes, Some(30));
+        assert_eq!(
+            settings
+                .skip_permission_flags
+                .get("claude")
+                .map(String::as_str),
+            Some("--dangerously-skip-permissions")
+        );
 
         if let Some(val) = original {
             env::set_var("CODESANDBOX_CONFIG_HOME", val);


### PR DESCRIPTION
## Summary
- allow specifying distinct permission-skip flags per agent via `skip_permission_flags`
- thread optional flag through container attach logic
- document per-agent permission configuration

## Testing
- `cargo fmt --all`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d95e5524832fa21bcdbf4ff91a00