### PR TITLE
Add global container listing via ps subcommand and fallback table

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,8 @@ pub struct Cli {
 pub enum Commands {
     #[command(about = "List containers for this directory and optionally attach to one")]
     Ls,
+    #[command(about = "List all running Code Sandbox containers")]
+    Ps,
 }
 
 #[derive(ValueEnum, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::io::{self, Write};
 use cli::{Cli, Commands};
 use container::{
     auto_remove_old_containers, check_docker_availability, cleanup_containers, create_container,
-    generate_container_name, list_containers, resume_container,
+    generate_container_name, list_all_containers, list_containers, resume_container,
 };
 use settings::load_settings;
 use state::{clear_last_container, load_last_container, save_last_container};
@@ -60,6 +60,19 @@ async fn main() -> Result<()> {
         }
     }
 
+    if let Some(Commands::Ps) = cli.command {
+        let containers = list_all_containers()?;
+        if containers.is_empty() {
+            println!("No running Code Sandbox containers found.");
+            return Ok(());
+        }
+        println!("{:<20}{}", "Project", "Container");
+        for (project, name) in containers {
+            println!("{:<20}{}", project, name);
+        }
+        return Ok(());
+    }
+
     if let Some(Commands::Ls) = cli.command {
         let containers = list_containers(&current_dir)?;
         if containers.is_empty() {
@@ -67,6 +80,16 @@ async fn main() -> Result<()> {
                 "No Code Sandbox containers found for directory {}",
                 current_dir.display()
             );
+            let global = list_all_containers()?;
+            if global.is_empty() {
+                println!("No running Code Sandbox containers found.");
+            } else {
+                println!("\nCurrently running containers:");
+                println!("{:<20}{}", "Project", "Container");
+                for (project, name) in global {
+                    println!("{:<20}{}", project, name);
+                }
+            }
             return Ok(());
         }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -29,6 +29,12 @@ fn parse_ls_subcommand() {
 }
 
 #[test]
+fn parse_ps_subcommand() {
+    let cli = Cli::parse_from(["codesandbox", "ps"]);
+    assert!(matches!(cli.command, Some(Commands::Ps)));
+}
+
+#[test]
 fn conflicting_flags_error() {
     let result = Cli::try_parse_from(["codesandbox", "--continue", "--cleanup"]);
     assert!(result.is_err());


### PR DESCRIPTION
## Summary
- support `ps` subcommand to list running Code Sandbox containers across projects
- display table of all running containers when `ls` finds none in current branch
- test CLI parsing for `ps` command

## Testing
- `cargo clippy --tests`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a40c688acc832f87a5d3f5e3f52fac