### PR TITLE
Add interactive ps command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,9 @@ pub struct Cli {
 pub enum Commands {
     #[command(about = "List containers for this directory and optionally attach to one")]
     Ls,
-    #[command(about = "List all running Code Sandbox containers")]
+    #[command(
+        about = "List all running Code Sandbox containers and optionally attach or open their directory"
+    )]
     Ps,
 }
 

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -143,6 +143,12 @@ case "$cmd" in
     echo "csb-claude-proj-main-123456"
     echo "unrelated"
     ;;
+  inspect)
+    name="${!#}"
+    if [ "$name" = "csb-claude-proj-main-123456" ]; then
+      echo "/projects/proj"
+    fi
+    ;;
   *)
     exit 1
     ;;
@@ -167,4 +173,5 @@ esac
     assert_eq!(containers.len(), 1);
     assert_eq!(containers[0].0, "proj");
     assert_eq!(containers[0].1, "csb-claude-proj-main-123456");
+    assert_eq!(containers[0].2.as_deref(), Some("/projects/proj"));
 }


### PR DESCRIPTION
## Summary
- make `ps` interactive with options to attach or open a container's directory
- expose host directory paths by inspecting container mounts
- test list_all_containers for project and path discovery

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a41330f49c832fab5a81a9a804aedc