### PR TITLE
fix: use dynamic host for terminal WebSocket

### DIFF
--- a/web/src/components/terminal.tsx
+++ b/web/src/components/terminal.tsx
@@ -53,7 +53,10 @@ export default function Terminal({ containerName }: TerminalProps) {
                 }
             }, 100);
 
-            const ws = new WebSocket(`ws://localhost:6789/terminal/${activeContainer}`);
+            const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+            const ws = new WebSocket(
+                `${protocol}://${window.location.hostname}:6789/terminal/${activeContainer}`
+            );
             wsRef.current = ws;
 
             ws.onopen = () => {


### PR DESCRIPTION
## Summary
- use current page's protocol/hostname to create terminal WebSocket instead of localhost

## Testing
- `cargo test`
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48ba4bc00832fbff35efa9ffdc25f