### PR TITLE
Exclude environment files from container mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,20 @@ Additional behavior can be configured via `settings.json` located at
         "claude": "--dangerously-skip-permissions",
         "gemini": "--yolo",
         "qwen": "--yolo"
-    }
+    },
+    "env_files": [
+        ".env",
+        ".env.local"
+    ]
 }
 ```
 
 The `skip_permission_flags` map assigns a permission-skipping flag to each
 agent. When launching an agent, the corresponding flag is appended to the
 command.
+
+Environment files listed in `env_files` are masked from the container by
+overlaying them with empty temporary files, keeping sensitive data on the host.
 
 ## Cleanup
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -3,9 +3,11 @@ use chrono::{Local, Utc};
 use std::env;
 use std::path::Path;
 use std::process::Command;
+use tempfile::NamedTempFile;
 
 use crate::cli::Agent;
 use crate::config::{get_claude_config_dir, get_claude_json_paths};
+use crate::settings::load_settings;
 
 fn sanitize(name: &str) -> String {
     name.to_lowercase()
@@ -163,7 +165,7 @@ fn get_container_directory(name: &str) -> Result<Option<String>> {
         return Ok(None);
     }
     let paths = String::from_utf8_lossy(&output.stdout);
-    
+
     // Filter out config directories and get the first valid project path
     for line in paths.lines() {
         let path = line.trim();
@@ -319,6 +321,19 @@ pub async fn create_container(
         "-v",
         &format!("{}:{}", current_dir.display(), current_dir.display()),
     ]);
+
+    let settings = load_settings().unwrap_or_default();
+    let mut _env_file_overlays: Vec<NamedTempFile> = Vec::new();
+    for file in settings.env_files.iter() {
+        let target = current_dir.join(file);
+        let tmp = NamedTempFile::new().context("Failed to create temp file for env masking")?;
+        docker_run.args(&[
+            "-v",
+            &format!("{}:{}:ro", tmp.path().display(), target.display()),
+        ]);
+        println!("Excluding {} from container mount", target.display());
+        _env_file_overlays.push(tmp);
+    }
 
     if let Some(dir) = additional_dir {
         docker_run.args(&["-v", &format!("{}:{}:ro", dir.display(), dir.display())]);

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -4,6 +4,9 @@ mod config;
 #[path = "../src/cli.rs"]
 mod cli;
 
+#[path = "../src/settings.rs"]
+mod settings;
+
 #[path = "../src/container.rs"]
 mod container;
 

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -4,6 +4,9 @@ mod config;
 #[path = "../src/cli.rs"]
 mod cli;
 
+#[path = "../src/settings.rs"]
+mod settings;
+
 #[path = "../src/container.rs"]
 mod container;
 


### PR DESCRIPTION
## Summary
- allow environment file exclusion list to be configured via `settings.json` with sensible defaults
- document `env_files` setting and update tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a559e48150832f86117f416b738f7d