### PR TITLE
Exclude environment files from container mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,21 @@ Additional behavior can be configured via `settings.json` located at
         "claude": "--dangerously-skip-permissions",
         "gemini": "--yolo",
         "qwen": "--yolo"
-    }
+    },
+    "env_files": [
+        ".env",
+        ".env.local"
+    ]
 }
 ```
 
 The `skip_permission_flags` map assigns a permission-skipping flag to each
 agent. When launching an agent, the corresponding flag is appended to the
 command.
+
+Environment files listed in `env_files` that exist in the project directory are
+masked from the container by overlaying them with empty temporary files,
+keeping sensitive data on the host.
 
 ## Cleanup
 

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -4,6 +4,9 @@ mod config;
 #[path = "../src/cli.rs"]
 mod cli;
 
+#[path = "../src/settings.rs"]
+mod settings;
+
 #[path = "../src/container.rs"]
 mod container;
 
@@ -174,4 +177,58 @@ esac
     assert_eq!(containers[0].0, "proj");
     assert_eq!(containers[0].1, "csb-claude-proj-main-123456");
     assert_eq!(containers[0].2.as_deref(), Some("/projects/proj"));
+}
+
+#[tokio::test]
+async fn create_container_masks_only_existing_env_files() {
+    let _lock = DOCKER_LOCK.lock().unwrap();
+    let tmp = tempdir().expect("temp dir");
+    let project_dir = tmp.path().join("proj");
+    fs::create_dir(&project_dir).expect("create project dir");
+    fs::write(project_dir.join(".env"), "SECRET=1").expect("write env");
+
+    let bin_dir = tmp.path().join("bin");
+    fs::create_dir(&bin_dir).unwrap();
+    let run_log = tmp.path().join("run.log");
+    let script = format!(
+        "#!/bin/bash\ncmd=\"$1\"; shift\ncase \"$cmd\" in\n  build) exit 0 ;;\n  run) echo \"$@\" > \"{}\"; exit 0 ;;\n  exec) exit 0 ;;\n  *) exit 0 ;;\nesac\n",
+        run_log.display()
+    );
+    let docker_path = bin_dir.join("docker");
+    fs::write(&docker_path, script).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&docker_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&docker_path, perms).unwrap();
+    }
+
+    let original_path = env::var("PATH").unwrap_or_default();
+    env::set_var("PATH", format!("{}:{}", bin_dir.display(), original_path));
+
+    container::create_container("test", &project_dir, None, &Agent::Claude, None)
+        .await
+        .unwrap();
+
+    env::set_var("PATH", original_path);
+
+    let run_args = fs::read_to_string(&run_log).unwrap();
+    assert!(run_args.contains(&project_dir.join(".env").display().to_string()));
+    assert!(!run_args.contains(&project_dir.join(".env.local").display().to_string()));
+    assert!(!run_args.contains(
+        &project_dir
+            .join(".env.development.local")
+            .display()
+            .to_string()
+    ));
+    assert!(!run_args.contains(
+        &project_dir.join(".env.test.local").display().to_string()
+    ));
+    assert!(!run_args.contains(
+        &project_dir
+            .join(".env.production.local")
+            .display()
+            .to_string()
+    ));
 }

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -4,6 +4,9 @@ mod config;
 #[path = "../src/cli.rs"]
 mod cli;
 
+#[path = "../src/settings.rs"]
+mod settings;
+
 #[path = "../src/container.rs"]
 mod container;
 


### PR DESCRIPTION
## Summary
- only mask environment files that actually exist
- document that env masking only applies to existing files
- test that missing env files are not mounted into the container

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a559e48150832f86117f416b738f7d