### PR TITLE
Add automatic language tooling installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Running an agent inside an isolated container provides several benefits:
 -   **Automatic Workspace Mounting**: Seamlessly mounts your current directory to same path with the host machine in the container
 -   **Configuration Management**: Automatically copies and applies your agent configurations
 -   **Intelligent Naming**: Generates contextual container names to prevent conflicts (`csb-{agent}-{dir}-{branch}-{yymmddhhmm}`)
+-   **Language Tooling**: Detects common project languages and installs missing package managers like Cargo, npm, pip, Composer, Go, or Bundler
 
 ### Workflow Management
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,0 +1,116 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ProjectLanguage {
+    Rust,
+    NodeJs,
+    Python,
+    Go,
+    Php,
+    Ruby,
+}
+
+impl ProjectLanguage {
+    pub fn name(&self) -> &'static str {
+        match self {
+            ProjectLanguage::Rust => "Rust",
+            ProjectLanguage::NodeJs => "Node.js",
+            ProjectLanguage::Python => "Python",
+            ProjectLanguage::Go => "Go",
+            ProjectLanguage::Php => "PHP",
+            ProjectLanguage::Ruby => "Ruby",
+        }
+    }
+
+    pub fn tool(&self) -> &'static str {
+        match self {
+            ProjectLanguage::Rust => "cargo",
+            ProjectLanguage::NodeJs => "npm",
+            ProjectLanguage::Python => "pip",
+            ProjectLanguage::Go => "go",
+            ProjectLanguage::Php => "composer",
+            ProjectLanguage::Ruby => "bundle",
+        }
+    }
+
+    pub fn install_cmd(&self) -> &'static str {
+        match self {
+            ProjectLanguage::Rust => "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && ~/.cargo/bin/rustup component add rustfmt clippy",
+            ProjectLanguage::NodeJs => "curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash - && sudo apt-get install -y nodejs",
+            ProjectLanguage::Python => "sudo apt-get update && sudo apt-get install -y python3 python3-pip",
+            ProjectLanguage::Go => "wget https://go.dev/dl/go1.24.5.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf go1.24.5.linux-amd64.tar.gz && rm go1.24.5.linux-amd64.tar.gz",
+            ProjectLanguage::Php => "sudo apt-get update && sudo apt-get install -y php-cli unzip && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer",
+            ProjectLanguage::Ruby => "sudo apt-get update && sudo apt-get install -y ruby-full && sudo gem install bundler",
+        }
+    }
+}
+
+pub fn detect_project_languages(dir: &Path) -> Vec<ProjectLanguage> {
+    let mut langs = Vec::new();
+    if dir.join("Cargo.toml").exists() {
+        langs.push(ProjectLanguage::Rust);
+    }
+    if dir.join("package.json").exists() {
+        langs.push(ProjectLanguage::NodeJs);
+    }
+    if dir.join("requirements.txt").exists() || dir.join("pyproject.toml").exists() {
+        langs.push(ProjectLanguage::Python);
+    }
+    if dir.join("go.mod").exists() {
+        langs.push(ProjectLanguage::Go);
+    }
+    if dir.join("composer.json").exists() {
+        langs.push(ProjectLanguage::Php);
+    }
+    if dir.join("Gemfile").exists() {
+        langs.push(ProjectLanguage::Ruby);
+    }
+    langs
+}
+
+pub fn ensure_language_tools(container_name: &str, languages: &[ProjectLanguage]) -> Result<()> {
+    for lang in languages {
+        let tool = lang.tool();
+        let check_status = Command::new("docker")
+            .args([
+                "exec",
+                container_name,
+                "bash",
+                "-lc",
+                &format!("command -v {tool}"),
+            ])
+            .status()
+            .with_context(|| format!("Failed to check for {}", tool))?;
+        if check_status.success() {
+            continue;
+        }
+        println!("Installing toolchain for {}...", lang.name());
+        let install_status = Command::new("docker")
+            .args(["exec", container_name, "bash", "-lc", lang.install_cmd()])
+            .status()
+            .with_context(|| format!("Failed to install {}", tool))?;
+        if !install_status.success() {
+            anyhow::bail!("Installation for {} failed", tool);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detect_languages() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "").unwrap();
+        fs::write(tmp.path().join("package.json"), "").unwrap();
+        let langs = detect_project_languages(tmp.path());
+        assert!(langs.contains(&ProjectLanguage::Rust));
+        assert!(langs.contains(&ProjectLanguage::NodeJs));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod config;
 mod container;
+mod language;
 mod server;
 mod settings;
 mod state;

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -7,6 +7,9 @@ mod cli;
 #[path = "../src/settings.rs"]
 mod settings;
 
+#[path = "../src/language.rs"]
+mod language;
+
 #[path = "../src/container.rs"]
 mod container;
 
@@ -30,6 +33,16 @@ fn test_generate_container_name_with_git_repo() {
         .current_dir(&repo_path)
         .status()
         .expect("git init");
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo_path)
+        .status()
+        .expect("git config email");
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo_path)
+        .status()
+        .expect("git config name");
     Command::new("git")
         .args(["checkout", "-b", "Feature/Test"])
         .current_dir(&repo_path)
@@ -222,9 +235,7 @@ async fn create_container_masks_only_existing_env_files() {
             .display()
             .to_string()
     ));
-    assert!(!run_args.contains(
-        &project_dir.join(".env.test.local").display().to_string()
-    ));
+    assert!(!run_args.contains(&project_dir.join(".env.test.local").display().to_string()));
     assert!(!run_args.contains(
         &project_dir
             .join(".env.production.local")

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -7,6 +7,9 @@ mod cli;
 #[path = "../src/settings.rs"]
 mod settings;
 
+#[path = "../src/language.rs"]
+mod language;
+
 #[path = "../src/container.rs"]
 mod container;
 


### PR DESCRIPTION
## Summary
- detect common project languages via manifest files
- install missing package managers inside containers
- document language-aware tooling in README

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a73ce2c110832f9e8a9f664cfd7ade