### PR TITLE
feat: mount configs for gemini, qwen and cursor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,7 +81,7 @@ impl Agent {
             Agent::Gemini => "gemini",
             Agent::Codex => "codex",
             Agent::Qwen => "qwen",
-            Agent::Cursor => "cursor",
+            Agent::Cursor => "cursor-agent",
         }
     }
 }


### PR DESCRIPTION
## Summary
- mount configuration directories for gemini, qwen and cursor agents
- add helper to attach agent configs when creating container
- run cursor agent via `cursor-agent` while mounting its `.cursor` config directory

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68a7425075e8832f88dcdc57d8dd9f4d