### PR TITLE
Forward --continue flag to resumed agent

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,13 @@ async fn main() -> Result<()> {
     if cli.continue_ {
         match load_last_container()? {
             Some(container_name) => {
-                resume_container(&container_name, &cli.agent, skip_permission_flag.as_deref())
-                    .await?;
+                resume_container(
+                    &container_name,
+                    &cli.agent,
+                    true,
+                    skip_permission_flag.as_deref(),
+                )
+                .await?;
                 return Ok(());
             }
             None => {
@@ -146,7 +151,8 @@ async fn main() -> Result<()> {
                     env::set_current_dir(path)
                         .with_context(|| format!("Failed to change directory to {}", path))?;
                     let (_, name, _) = &containers[num - 1];
-                    resume_container(name, &cli.agent, skip_permission_flag.as_deref()).await?;
+                    resume_container(name, &cli.agent, false, skip_permission_flag.as_deref())
+                        .await?;
                 } else {
                     println!("Path not available for selected container");
                 }
@@ -192,7 +198,8 @@ async fn main() -> Result<()> {
         match input.parse::<usize>() {
             Ok(num) if num >= 1 && num <= containers.len() => {
                 let selected = &containers[num - 1];
-                resume_container(selected, &cli.agent, skip_permission_flag.as_deref()).await?;
+                resume_container(selected, &cli.agent, false, skip_permission_flag.as_deref())
+                    .await?;
             }
             _ => println!("Invalid selection"),
         }
@@ -203,7 +210,7 @@ async fn main() -> Result<()> {
         let containers = list_containers(&current_dir)?;
         if let Some(latest) = containers.first() {
             println!("Attaching to existing container for worktree: {}", latest);
-            resume_container(latest, &cli.agent, skip_permission_flag.as_deref()).await?;
+            resume_container(latest, &cli.agent, false, skip_permission_flag.as_deref()).await?;
             return Ok(());
         }
     }


### PR DESCRIPTION
## Summary
- forward `--continue` to the CLI agent when resuming a container
- centralize agent command construction with optional `--continue`
- add unit tests for agent command generation

## Testing
- `cargo test` *(fails: config::tests::test_get_claude_config_dir_none)*

------
https://chatgpt.com/codex/tasks/task_e_68a852d9bd6c832fa849bd66fd9ca49a