### PR TITLE
Add shell option to attach container without starting agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ Environment files listed in `env_files` that exist in the project directory are
 masked from the container by overlaying them with empty temporary files,
 keeping sensitive data on the host.
 
+## Shell Access
+
+To start a container without launching an agent and open a shell:
+
+```bash
+codesandbox --shell
+```
+
 ## Cleanup
 
 To remove all containers created from the current directory:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,9 @@ pub struct Cli {
     )]
     pub worktree: Option<String>,
 
+    #[arg(long, help = "Attach to container shell without starting the agent")]
+    pub shell: bool,
+
     #[arg(
         long,
         value_enum,

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> Result<()> {
                     &cli.agent,
                     true,
                     skip_permission_flag.as_deref(),
+                    cli.shell,
                 )
                 .await?;
                 return Ok(());
@@ -151,8 +152,14 @@ async fn main() -> Result<()> {
                     env::set_current_dir(path)
                         .with_context(|| format!("Failed to change directory to {}", path))?;
                     let (_, name, _) = &containers[num - 1];
-                    resume_container(name, &cli.agent, false, skip_permission_flag.as_deref())
-                        .await?;
+                    resume_container(
+                        name,
+                        &cli.agent,
+                        false,
+                        skip_permission_flag.as_deref(),
+                        cli.shell,
+                    )
+                    .await?;
                 } else {
                     println!("Path not available for selected container");
                 }
@@ -198,8 +205,14 @@ async fn main() -> Result<()> {
         match input.parse::<usize>() {
             Ok(num) if num >= 1 && num <= containers.len() => {
                 let selected = &containers[num - 1];
-                resume_container(selected, &cli.agent, false, skip_permission_flag.as_deref())
-                    .await?;
+                resume_container(
+                    selected,
+                    &cli.agent,
+                    false,
+                    skip_permission_flag.as_deref(),
+                    cli.shell,
+                )
+                .await?;
             }
             _ => println!("Invalid selection"),
         }
@@ -210,7 +223,14 @@ async fn main() -> Result<()> {
         let containers = list_containers(&current_dir)?;
         if let Some(latest) = containers.first() {
             println!("Attaching to existing container for worktree: {}", latest);
-            resume_container(latest, &cli.agent, false, skip_permission_flag.as_deref()).await?;
+            resume_container(
+                latest,
+                &cli.agent,
+                false,
+                skip_permission_flag.as_deref(),
+                cli.shell,
+            )
+            .await?;
             return Ok(());
         }
     }
@@ -236,6 +256,7 @@ async fn main() -> Result<()> {
         additional_dir.as_deref(),
         &cli.agent,
         skip_permission_flag.as_deref(),
+        cli.shell,
     )
     .await?;
     save_last_container(&container_name)?;

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -114,6 +114,12 @@ fn parse_agent_option() {
 }
 
 #[test]
+fn parse_shell_flag() {
+    let cli = Cli::parse_from(["codesandbox", "--shell"]);
+    assert!(cli.shell);
+}
+
+#[test]
 fn parse_worktree_option() {
     let cli = Cli::parse_from(["codesandbox", "--worktree", "feature"]);
     assert_eq!(cli.worktree.as_deref(), Some("feature"));

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -220,7 +220,7 @@ async fn create_container_masks_only_existing_env_files() {
     let original_path = env::var("PATH").unwrap_or_default();
     env::set_var("PATH", format!("{}:{}", bin_dir.display(), original_path));
 
-    container::create_container("test", &project_dir, None, &Agent::Claude, None)
+    container::create_container("test", &project_dir, None, &Agent::Claude, None, false)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- add `--shell` flag to attach to container without launching an agent
- allow container creation and resume functions to open a plain shell
- document shell access in README and cover new flag in tests

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: function list_containers is never used, and more)*
- `cargo test` *(fails: config::tests::test_get_claude_json_paths_multiple_sources)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42ff7674832f8cc949cf27aca23b