### PR TITLE
feat: add npm packaging for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+dist/
 .idea/
 .vscode/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ cargo install codesandbox
 
 Visit the [Releases](https://github.com/your-org/code-sandbox/releases) page to download pre-built binaries for your platform.
 
+### Method 5: Install via npm
+
+```bash
+npm install -g codesandbox-cli
+```
+
+This will compile the CLI using Rust's build tool and expose a `codesandbox` command via npm.
+
 ## Usage
 
 ### Quick Start

--- a/bin/codesandbox.js
+++ b/bin/codesandbox.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+const os = require('os');
+
+const isWin = os.platform() === 'win32';
+const binName = isWin ? 'codesandbox.exe' : 'codesandbox';
+const binPath = path.join(__dirname, '..', 'dist', binName);
+
+const args = process.argv.slice(2);
+const child = spawn(binPath, args, { stdio: 'inherit' });
+
+child.on('close', (code) => {
+  process.exit(code);
+});

--- a/install.js
+++ b/install.js
@@ -1,0 +1,21 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const targetDir = path.join(__dirname, 'dist');
+fs.mkdirSync(targetDir, { recursive: true });
+
+const isWin = os.platform() === 'win32';
+const binName = isWin ? 'codesandbox.exe' : 'codesandbox';
+
+try {
+  execSync('cargo build --release', { stdio: 'inherit' });
+  const src = path.join(__dirname, 'target', 'release', binName);
+  const dest = path.join(targetDir, binName);
+  fs.copyFileSync(src, dest);
+  fs.chmodSync(dest, 0o755);
+} catch (err) {
+  console.error('Failed to build codesandbox binary', err);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "codesandbox-cli",
+  "version": "0.1.0",
+  "description": "Code Sandbox CLI packaged for npm",
+  "bin": {
+    "codesandbox": "./bin/codesandbox.js"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "install.js"
+  ],
+  "scripts": {
+    "postinstall": "node install.js",
+    "test": "node -e \"console.log('No tests')\""
+  },
+  "keywords": [
+    "cli",
+    "codesandbox",
+    "rust",
+    "docker"
+  ],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add package.json, install script, and wrapper to distribute codesandbox via npm
- document npm installation method
- ignore dist directory in git

## Testing
- `node bin/codesandbox.js --version`
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ada9b8eca8832f8cbd53e4197872bc