### PR TITLE
feat: add stop and restart server commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ Run it as a background daemon:
 codesandbox serve -d
 ```
 
+Stop the server:
+
+```bash
+codesandbox stop
+```
+
+Restart the server (optionally in the background):
+
+```bash
+codesandbox restart
+codesandbox restart -d
+```
+
 The server listens on port 6789. Query the changes for a specific container:
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,10 +61,13 @@ pub enum Commands {
     Serve {
         #[arg(short = 'd', long = "daemon", help = "Run server in the background")]
         daemon: bool,
-        #[arg(long, help = "Stop the running server", conflicts_with = "restart")]
-        stop: bool,
-        #[arg(long, help = "Restart the server", conflicts_with = "stop")]
-        restart: bool,
+    },
+    #[command(about = "Stop the running Code Sandbox API server")]
+    Stop,
+    #[command(about = "Restart the Code Sandbox API server")]
+    Restart {
+        #[arg(short = 'd', long = "daemon", help = "Run server in the background")]
+        daemon: bool,
     },
 }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -39,11 +39,7 @@ fn parse_serve_subcommand() {
     let cli = Cli::parse_from(["codesandbox", "serve"]);
     assert!(matches!(
         cli.command,
-        Some(Commands::Serve {
-            daemon: false,
-            stop: false,
-            restart: false
-        })
+        Some(Commands::Serve { daemon: false })
     ));
 }
 
@@ -52,37 +48,31 @@ fn parse_serve_daemon_flag() {
     let cli = Cli::parse_from(["codesandbox", "serve", "-d"]);
     assert!(matches!(
         cli.command,
-        Some(Commands::Serve {
-            daemon: true,
-            stop: false,
-            restart: false
-        })
+        Some(Commands::Serve { daemon: true })
     ));
 }
 
 #[test]
-fn parse_serve_stop_flag() {
-    let cli = Cli::parse_from(["codesandbox", "serve", "--stop"]);
+fn parse_stop_subcommand() {
+    let cli = Cli::parse_from(["codesandbox", "stop"]);
+    assert!(matches!(cli.command, Some(Commands::Stop)));
+}
+
+#[test]
+fn parse_restart_subcommand() {
+    let cli = Cli::parse_from(["codesandbox", "restart"]);
     assert!(matches!(
         cli.command,
-        Some(Commands::Serve {
-            daemon: false,
-            stop: true,
-            restart: false
-        })
+        Some(Commands::Restart { daemon: false })
     ));
 }
 
 #[test]
-fn parse_serve_restart_flag() {
-    let cli = Cli::parse_from(["codesandbox", "serve", "--restart"]);
+fn parse_restart_daemon_flag() {
+    let cli = Cli::parse_from(["codesandbox", "restart", "-d"]);
     assert!(matches!(
         cli.command,
-        Some(Commands::Serve {
-            daemon: false,
-            stop: false,
-            restart: true
-        })
+        Some(Commands::Restart { daemon: true })
     ));
 }
 


### PR DESCRIPTION
## Summary
- add dedicated `stop` and `restart` subcommands to manage the API server
- handle new subcommands in main
- document server stop/restart usage and update CLI tests

## Testing
- `cargo test` *(fails: called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" })*


------
https://chatgpt.com/codex/tasks/task_e_68af125d1a08832f9cb3d27ab3666a96