### PR TITLE
Avoid creating env placeholders when masking

### DIFF
--- a/src/container/runtime.rs
+++ b/src/container/runtime.rs
@@ -121,7 +121,7 @@ fn build_run_command(
     let mut env_file_overlays: Vec<NamedTempFile> = Vec::new();
     for file in settings.env_files.iter() {
         let target = current_dir.join(file);
-        if target.exists() {
+        if target.is_file() {
             let tmp = NamedTempFile::new().context("Failed to create temp file for env masking")?;
             docker_run.args([
                 "-v",

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -242,4 +242,10 @@ async fn create_container_masks_only_existing_env_files() {
             .display()
             .to_string()
     ));
+
+    // Ensure no new env files were created on the host
+    assert!(!project_dir.join(".env.local").exists());
+    assert!(!project_dir.join(".env.development.local").exists());
+    assert!(!project_dir.join(".env.test.local").exists());
+    assert!(!project_dir.join(".env.production.local").exists());
 }


### PR DESCRIPTION
## Summary
- check that env file exists before overlaying so docker won't create new `.env*` files
- test that container creation doesn't generate missing env files

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68af183b6708832f98ef5c97b5334e2f