### PR TITLE
Allow connecting to terminal WebSocket without token

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -162,7 +162,7 @@ async fn get_changed(
 
 #[derive(Deserialize)]
 pub(crate) struct TerminalParams {
-    token: String,
+    token: Option<String>,
 }
 
 pub(crate) async fn terminal_ws(
@@ -170,7 +170,13 @@ pub(crate) async fn terminal_ws(
     Path(container): Path<String>,
     Query(params): Query<TerminalParams>,
 ) -> Response {
-    if params.token == container {
+    let token_matches = params
+        .token
+        .as_ref()
+        .map(|t| t == &container)
+        .unwrap_or(true);
+
+    if token_matches {
         ws.on_upgrade(move |socket| handle_terminal(socket, container))
     } else {
         (StatusCode::UNAUTHORIZED, "invalid token").into_response()

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -28,6 +28,23 @@ async fn websocket_route_requires_upgrade() {
 }
 
 #[tokio::test]
+async fn websocket_route_without_token_requires_upgrade() {
+    let app = Router::new().route("/terminal/:container", get(server::terminal_ws));
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/terminal/my-container")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn serves_frontend_index() {
     let app = Router::new().fallback_service(
         get_service(ServeDir::new("web/dist"))


### PR DESCRIPTION
## Summary
- accept missing `token` query parameter when upgrading to the terminal WebSocket
- add coverage ensuring the `/terminal/:container` route still requires a WebSocket upgrade even without a token

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68af1ce05f68832fb0c2efa36e0b59fa