### PR TITLE
fix: run changed API inside repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "clap",
  "futures",
  "home",
+ "once_cell",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ tower-http = { version = "0.4", features = ["fs"] }
 tower = "0.4"
 atty = "0.2"
 base64 = "0.21"
+once_cell = "1.19"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- track container paths when starting sandboxes
- run git status/diff with correct working directory for `/api/changed`
- add once_cell dependency

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings` *(fails: variables can be used directly in format strings, etc.)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b009e31ea0832fa98d405ee1740cd7