### PR TITLE
refactor: remove tmux dependency for web UI

### DIFF
--- a/src/container/runtime.rs
+++ b/src/container/runtime.rs
@@ -457,7 +457,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     gnupg \
     lsb-release \
-    tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js v22


### PR DESCRIPTION
## Summary
- drop tmux from container image and server terminal startup
- simplify web terminal resizing logic

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b3faffe71c832f9e8e1e8dbe29fae1