### PR TITLE
feat: display ps output as table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "comfy-table",
  "futures",
  "home",
  "once_cell",
@@ -324,6 +325,17 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "comfy-table"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8e18d0dca9578507f13f9803add0df13362b02c501c1c17734f0dbb52eaf0b"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "core-foundation"
@@ -348,6 +360,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.2",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -385,6 +420,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -913,6 +957,12 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
@@ -1792,6 +1842,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ tower = "0.4"
 atty = "0.2"
 base64 = "0.21"
 once_cell = "1.19"
+comfy-table = "7.1"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod worktree;
 
 use anyhow::{Context, Result};
 use base64::Engine as _;
+use comfy_table::{presets::ASCII_FULL, Table};
 use std::env;
 use std::fs;
 use std::io::{self, Write};
@@ -144,16 +145,18 @@ async fn main() -> Result<()> {
             println!("No running Code Sandbox containers found.");
             return Ok(());
         }
-        println!("{:<4}{:<20}{:<20}Directory", "No.", "Project", "Container");
+        let mut table = Table::new();
+        table.load_preset(ASCII_FULL);
+        table.set_header(vec!["No.", "Project", "Container", "Directory"]);
         for (i, (project, name, path)) in containers.iter().enumerate() {
-            println!(
-                "{:<4}{:<20}{:<20}{}",
-                i + 1,
-                project,
-                name,
-                path.as_deref().unwrap_or("")
-            );
+            table.add_row(vec![
+                (i + 1).to_string(),
+                project.clone(),
+                name.clone(),
+                path.clone().unwrap_or_default(),
+            ]);
         }
+        println!("{table}");
         print!(
             "Select a container to attach (number), or type 'cd <number>' to open its directory: "
         );
@@ -342,7 +345,6 @@ async fn main() -> Result<()> {
     .await?;
     save_last_container(&container_name)?;
 
-    
     if use_web {
         maybe_open_web(
             &container_name,


### PR DESCRIPTION
## Summary
- render `codesandbox ps` output as an ASCII table
- add comfy-table dependency

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b727723938832fa9b691145a40361f