### PR TITLE
fix: detect agent for existing containers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,10 +6,7 @@ use std::path::PathBuf;
 #[command(about = "Agent Sandbox - Docker container manager")]
 #[command(version = env!("CARGO_PKG_VERSION"))]
 pub struct Cli {
-    #[arg(
-        long,
-        help = "Resume the last created container",
-    )]
+    #[arg(long, help = "Resume the last created container")]
     pub continue_: bool,
 
     #[arg(
@@ -86,6 +83,25 @@ impl Agent {
             Agent::Qwen => "qwen",
             Agent::Cursor => "cursor-agent",
         }
+    }
+
+    pub fn from_container_name(name: &str) -> Option<Self> {
+        let rest = name.strip_prefix("csb-")?;
+        for agent in [
+            Agent::Claude,
+            Agent::Gemini,
+            Agent::Codex,
+            Agent::Qwen,
+            Agent::Cursor,
+        ] {
+            let cmd = agent.command();
+            if let Some(after) = rest.strip_prefix(cmd) {
+                if after.starts_with('-') {
+                    return Some(agent);
+                }
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
## Summary
- detect the agent type from container name
- use detected agent when resuming containers via `--continue`, `ps`, `ls`, and worktree flows
- apply agent-specific permission skip flags when resuming or creating containers

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c040713698832f82a58654e1cf3cec